### PR TITLE
FEATURE::GET CLIENT IP FOR FAILSAFE ATTESTATION SERVICE

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -438,6 +438,10 @@ REDIS_URL = env("REDIS_URL", default="redis://localhost:6379/0")
 # ------------------------------------------------------------------------------
 ETHEREUM_NODE_URL = env("ETHEREUM_NODE_URL", default=None)
 
+# WEBHOOK
+# ------------------------------------------------------------------------------
+WEBHOOK_URL = env("WEBHOOK_URL", default=None)
+
 # Ethereum 4337 Bundler RPC
 # ------------------------------------------------------------------------------
 ETHEREUM_4337_BUNDLER_URL = env("ETHEREUM_4337_BUNDLER_URL", default=None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: nginx:alpine
     hostname: nginx
     ports:
-      - "8000:8000"
+      - "80:8000"
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - nginx-shared:/nginx
@@ -35,6 +35,7 @@ services:
 
   db:
     image: postgres:14-alpine
+    user: postgres
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [x] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`
- [x] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### Improvement 👾

Get Client IP for the FailSafe Attestation Service
